### PR TITLE
In addition to the voltage, also announce the battery percentage in the Radio Info menu.

### DIFF
--- a/firmware/source/user_interface/menuRadioInfos.c
+++ b/firmware/source/user_interface/menuRadioInfos.c
@@ -524,6 +524,8 @@ static void updateVoicePrompts(bool spellIt, bool firstRun)
 				int volts, mvolts;
 
 				voicePromptsAppendLanguageString(&currentLanguage->battery);
+				voicePromptsAppendInteger(getBatteryPercentage());
+				voicePromptsAppendPrompt(PROMPT_PERCENT);
 				getBatteryVoltage(&volts,  &mvolts);
 				snprintf(buffer, 17, " %1d.%1d", volts, mvolts);
 				voicePromptsAppendString(buffer);


### PR DESCRIPTION
Seems like an obvious lack, as this info does appear to be displayed visually, but if you disagree, feel free to reject this pull request.

I haven't figured out how to build the firmware locally yet, so this is as yet untested. However, hopefully I didn't manage to mess anything up in these two lines of code.

73s

N9LID